### PR TITLE
Don't report processing time per directory by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,10 @@ parent directory:
 - Last Modified (including all the descendents)
 - Total Number of Entries (Files, directories & symlinks)
 - Processing Time required to gather this information
+  This is only reported if `--enable-detailed-processing-time-metric` flag is
+  passed, to prevent possible explosion of stored size of prometheus metrics
+  when collected. This information is also not particularly useful outside
+  of debugging this exporter, and as it varies each run, compresses poorly.
 - Last updated
 
 ## Limitations

--- a/prometheus_dirsize_exporter/exporter.py
+++ b/prometheus_dirsize_exporter/exporter.py
@@ -136,6 +136,15 @@ def main():
         help="Number of minutes to wait before data collection runs",
         type=int,
     )
+    # Don't report amount of time it took to process each directory by
+    # default. This is highly variable, and probably causes prometheus to
+    # not compress metrics very well. Not particularly useful outside of
+    # debugging the exporter itself.
+    argparser.add_argument(
+        "--enable-detailed-processing-time-metric",
+        help="Report amount of time it took to process each directory",
+        action="store_true"
+    )
     argparser.add_argument(
         "--port", help="Port for the server to listen on", type=int, default=8000
     )
@@ -151,9 +160,10 @@ def main():
             metrics.ENTRIES_COUNT.labels(subdir_info.path).set(
                 subdir_info.entries_count
             )
-            metrics.PROCESSING_TIME.labels(subdir_info.path).set(
-                subdir_info.processing_time
-            )
+            if args.enable_detailed_processing_time_metric:
+                metrics.PROCESSING_TIME.labels(subdir_info.path).set(
+                    subdir_info.processing_time
+                )
             metrics.LAST_UPDATED.labels(subdir_info.path).set(time.time())
             print(f"Updated values for {subdir_info.path}")
         time.sleep(args.wait_time_minutes * 60)

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md") as f:
 
 setup(
     name="prometheus-dirsize-exporter",
-    version="1.2",
+    version="2.0",
     packages=find_packages(),
     license="3-BSD",
     long_description=long_description,


### PR DESCRIPTION
Prometheus metrics compress pretty well when they don't change over time as often. This metric is almost guaranteed to change each time, and thus will compress poorly. It's not particularly helpful outside of debugging this specific exporter, and thus will now be disabled by default.

Could also be the primary cause of
https://github.com/2i2c-org/infrastructure/issues/2930

Bumps version to 2.0 as this is technically a breaking change.