### PR TITLE
docker image: declare PYTHONUNBUFFERED=1 to flush regularly into stdout

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,4 +6,5 @@ ADD . /tmp/src
 
 RUN pip install /tmp/src
 
+ENV PYTHONUNBUFFERED=1
 ENTRYPOINT ["tini", "--"]


### PR DESCRIPTION
This project is referenced in jupyterhub/grafana-dashboards, where it is
deployed in a k8s context using this image without also declaring
PYTHONUNBUFFERED=1 environment variable.

With this change, people doesn't have to declare it when running this
image in order to get the logs flowing.
