### PR TITLE
ci: add dependabot to bump github actions

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,15 @@
+# dependabot.yaml reference: https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference
+#
+# Notes:
+# - Status and logs from dependabot are provided at
+#   https://github.com/2i2c-org/prometheus-dirsize-reporter/network/updates.
+#
+version: 2
+updates:
+  # Maintain dependencies in our GitHub Workflows
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly
+      time: "05:00"
+      timezone: Etc/UTC


### PR DESCRIPTION
Consider merging #26 before this, to avoid a flurry of PRs in conflict with #26.